### PR TITLE
Add support for service live-creation and expose live-creation in the REST API

### DIFF
--- a/library/Director/Core/CoreApi.php
+++ b/library/Director/Core/CoreApi.php
@@ -292,7 +292,7 @@ class CoreApi implements DeploymentApiInterface
 
     public function supportsRuntimeCreationFor(IcingaObject $object)
     {
-        $valid = array('host');
+        $valid = array('host', 'service');
         return in_array($object->getShortTableName(), $valid);
     }
 
@@ -313,13 +313,34 @@ class CoreApi implements DeploymentApiInterface
 
         $key = $object->getShortTableName();
 
+        switch ($key) {
+            case 'host':
+                $objectGetter = sprintf(
+                    'get_%s("%s")',
+                    $key,
+                    $object->getObjectName()
+                );
+                break;
+            case 'service':
+                $objectGetter = sprintf(
+                    'get_%s("%s","%s")',
+                    $key,
+                    $object->getRelated('host')->getObjectName(),
+                    $object->getObjectName()
+                );
+                break;
+            default:
+                throw new RuntimeException(sprintf(
+                    'Object creation at runtime is not supported for "%s"',
+                    $key
+                ));
+        }
+
         $command = sprintf(
             "f = function() {\n"
-            . '  existing = get_%s("%s")'
+            . "  existing = " . $objectGetter
             . "\n  if (existing) { return false }"
             . "\n%s\n}\nInternal.run_with_activation_context(f)\n",
-            $key,
-            $object->get('object_name'),
             (string) $object
         );
 

--- a/library/Director/RestApi/IcingaObjectHandler.php
+++ b/library/Director/RestApi/IcingaObjectHandler.php
@@ -146,7 +146,14 @@ class IcingaObjectHandler extends RequestHandler
 
                 if ($object->hasBeenModified()) {
                     $status = $object->hasBeenLoadedFromDb() ? 200 : 201;
-                    $object->store();
+                    if($object->store()){
+                        $liveCreationEnabled = $request->getParam('live-creation');
+                        if ($liveCreationEnabled === 'true'){
+                            if (!$this->api->createObjectAtRuntime($object)) {
+                                $status = 500;
+                            }
+                        }
+                    }
                     $response->setHttpResponseCode($status);
                 } else {
                     $response->setHttpResponseCode(304);


### PR DESCRIPTION
Hi all!
We would like to extend the experimental feature "live-creation", which currently supports only the creation of hosts, so that it supports the live creation of services also.

In addition to this, we would like to be able to perform the live-creation not only from the _icingacli_ commands, but also from the Director REST APIs, which can be useful for applications not having access to the command line interface.